### PR TITLE
fix scipy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "seaborn",
   "ucimlrepo",
   "tqdm",
-  "scipy",
+  "scipy<1.10",
   "scikit-learn",
   "category-encoders",
   "statsmodels",


### PR DESCRIPTION
This pr fixes #7 by setting a maximum scipy version in [pyproject.toml](https://github.com/gcskoenig/dipd/blob/main/pyproject.toml)